### PR TITLE
⚡ Bolt: Optimize JSON-LD parsing in MovieScraper

### DIFF
--- a/src/helpers/movie.helper.ts
+++ b/src/helpers/movie.helper.ts
@@ -123,23 +123,28 @@ export const getMovieRatingCount = (el: HTMLElement): number => {
   }
 };
 
-export const getMovieYear = (el: string): number => {
+export const getMovieYear = (jsonLd: any): number => {
   try {
-    const jsonLd = JSON.parse(el);
-    return +jsonLd.dateCreated;
+    if (jsonLd && jsonLd.dateCreated) {
+      return +jsonLd.dateCreated;
+    }
+    return null;
   } catch (error) {
     console.error('node-csfd-api: Error parsing JSON-LD', error);
     return null;
   }
 };
 
-export const getMovieDuration = (jsonLdRaw: string, el: HTMLElement): number => {
-  let duration = null;
+export const getMovieDuration = (jsonLd: any, el: HTMLElement): number => {
   try {
-    const jsonLd = JSON.parse(jsonLdRaw);
-    duration = jsonLd.duration;
-    return parseISO8601Duration(duration);
+    if (jsonLd && jsonLd.duration) {
+      return parseISO8601Duration(jsonLd.duration);
+    }
   } catch (error) {
+    // Ignore error and fall back to scraping
+  }
+
+  try {
     const origin = el.querySelector('.origin').innerText;
     const timeString = origin.split(',');
     if (timeString.length > 2) {
@@ -151,11 +156,13 @@ export const getMovieDuration = (jsonLdRaw: string, el: HTMLElement): number => 
       const hoursMinsRaw = timeRaw.split('min')[0];
       const hoursMins = hoursMinsRaw.split('h');
       // Resolve hours + minutes format
-      duration = hoursMins.length > 1 ? +hoursMins[0] * 60 + +hoursMins[1] : +hoursMins[0];
+      const duration = hoursMins.length > 1 ? +hoursMins[0] * 60 + +hoursMins[1] : +hoursMins[0];
       return duration;
     } else {
       return null;
     }
+  } catch (e) {
+    return null;
   }
 };
 

--- a/src/services/movie.service.ts
+++ b/src/services/movie.service.ts
@@ -41,7 +41,13 @@ export class MovieScraper {
     const pageClasses = movieHtml.querySelector('.page-content').classNames.split(' ');
     const asideNode = movieHtml.querySelector('.aside-movie-profile');
     const movieNode = movieHtml.querySelector('.main-movie-profile');
-    const jsonLd = movieHtml.querySelector('script[type="application/ld+json"]').innerText;
+    const jsonLdString = movieHtml.querySelector('script[type="application/ld+json"]').innerText;
+    let jsonLd = null;
+    try {
+      jsonLd = JSON.parse(jsonLdString);
+    } catch (e) {
+      console.error('node-csfd-api: Error parsing JSON-LD', e);
+    }
     return this.buildMovie(+movieId, movieNode, asideNode, pageClasses, jsonLd, options);
   }
 
@@ -50,7 +56,7 @@ export class MovieScraper {
     el: HTMLElement,
     asideEl: HTMLElement,
     pageClasses: string[],
-    jsonLd: string,
+    jsonLd: any,
     options: CSFDOptions
   ): CSFDMovie {
     return {

--- a/tests/movie.test.ts
+++ b/tests/movie.test.ts
@@ -54,12 +54,12 @@ const getJsonLd = (node: HTMLElement): string => {
 
 const getMovie = (
   node: HTMLElement
-): { pClasses: string[]; aside: HTMLElement; pNode: HTMLElement; jsonLd: string } => {
+): { pClasses: string[]; aside: HTMLElement; pNode: HTMLElement; jsonLd: any } => {
   return {
     pClasses: getPageClasses(node),
     aside: getAsideNode(node),
     pNode: getNode(node),
-    jsonLd: getJsonLd(node)
+    jsonLd: JSON.parse(getJsonLd(node))
   };
 };
 


### PR DESCRIPTION
💡 What: Optimized JSON-LD parsing in `MovieScraper`.
🎯 Why: The JSON-LD string was being parsed multiple times (in `getMovieYear` and `getMovieDuration`), which is inefficient.
📊 Impact: Reduces unnecessary JSON parsing operations for each movie scraped.
🔬 Measurement: Verified with `yarn test tests/movie.test.ts`. All tests passed.

---
*PR created automatically by Jules for task [7016294025625287554](https://jules.google.com/task/7016294025625287554) started by @bartholomej*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of movie data extraction by prioritizing structured metadata with fallback mechanisms for missing information
  * Enhanced error handling for movie year and duration retrieval
  * Increased robustness when encountering incomplete or invalid movie metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->