### PR TITLE
⚡ Bolt: Optimize JSON-LD parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-12 - JSON-LD Parsing Optimization
+**Learning:** The scraper was parsing the same JSON-LD string multiple times in different helper functions (`getMovieYear`, `getMovieDuration`).
+**Action:** Parse JSON-LD once in the service layer and pass the object to helpers. This reduces CPU overhead and avoids redundant parsing.

--- a/src/helpers/movie.helper.ts
+++ b/src/helpers/movie.helper.ts
@@ -123,23 +123,27 @@ export const getMovieRatingCount = (el: HTMLElement): number => {
   }
 };
 
-export const getMovieYear = (el: string): number => {
-  try {
-    const jsonLd = JSON.parse(el);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const getMovieYear = (jsonLd: any): number => {
+  if (jsonLd && jsonLd.dateCreated) {
     return +jsonLd.dateCreated;
-  } catch (error) {
-    console.error('node-csfd-api: Error parsing JSON-LD', error);
-    return null;
   }
+  return null;
 };
 
-export const getMovieDuration = (jsonLdRaw: string, el: HTMLElement): number => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const getMovieDuration = (jsonLd: any, el: HTMLElement): number => {
   let duration = null;
   try {
-    const jsonLd = JSON.parse(jsonLdRaw);
-    duration = jsonLd.duration;
-    return parseISO8601Duration(duration);
+    if (jsonLd && jsonLd.duration) {
+      duration = jsonLd.duration;
+      return parseISO8601Duration(duration);
+    }
   } catch (error) {
+    // Ignore error and try fallback
+  }
+
+  try {
     const origin = el.querySelector('.origin').innerText;
     const timeString = origin.split(',');
     if (timeString.length > 2) {
@@ -156,6 +160,8 @@ export const getMovieDuration = (jsonLdRaw: string, el: HTMLElement): number => 
     } else {
       return null;
     }
+  } catch (e) {
+    return null;
   }
 };
 

--- a/src/services/movie.service.ts
+++ b/src/services/movie.service.ts
@@ -42,7 +42,13 @@ export class MovieScraper {
     const asideNode = movieHtml.querySelector('.aside-movie-profile');
     const movieNode = movieHtml.querySelector('.main-movie-profile');
     const jsonLd = movieHtml.querySelector('script[type="application/ld+json"]').innerText;
-    return this.buildMovie(+movieId, movieNode, asideNode, pageClasses, jsonLd, options);
+    let movieJsonLd = null;
+    try {
+      movieJsonLd = JSON.parse(jsonLd);
+    } catch (e) {
+      console.error('node-csfd-api: Error parsing JSON-LD', e);
+    }
+    return this.buildMovie(+movieId, movieNode, asideNode, pageClasses, movieJsonLd, options);
   }
 
   private buildMovie(
@@ -50,7 +56,8 @@ export class MovieScraper {
     el: HTMLElement,
     asideEl: HTMLElement,
     pageClasses: string[],
-    jsonLd: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    jsonLd: any,
     options: CSFDOptions
   ): CSFDMovie {
     return {

--- a/tests/movie.test.ts
+++ b/tests/movie.test.ts
@@ -48,13 +48,16 @@ const getNode = (node: HTMLElement): HTMLElement => {
   return node.querySelector('.main-movie-profile') as HTMLElement;
 };
 
-const getJsonLd = (node: HTMLElement): string => {
-  return node.querySelector('script[type="application/ld+json"]')?.innerText ?? '{}';
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getJsonLd = (node: HTMLElement): any => {
+  const json = node.querySelector('script[type="application/ld+json"]')?.innerText ?? '{}';
+  return JSON.parse(json);
 };
 
 const getMovie = (
   node: HTMLElement
-): { pClasses: string[]; aside: HTMLElement; pNode: HTMLElement; jsonLd: string } => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): { pClasses: string[]; aside: HTMLElement; pNode: HTMLElement; jsonLd: any } => {
   return {
     pClasses: getPageClasses(node),
     aside: getAsideNode(node),


### PR DESCRIPTION
* 💡 What: Refactored `getMovieYear` and `getMovieDuration` to accept a parsed JSON-LD object instead of parsing the string repeatedly.
* 🎯 Why: Parsing large JSON strings is expensive and blocking. Doing it once per movie reduces CPU usage.
* 📊 Impact: Avoids redundant parsing for every movie scraped.
* 🔬 Measurement: Verified with `yarn test tests/movie.test.ts`.

---
*PR created automatically by Jules for task [5414485876459516438](https://jules.google.com/task/5414485876459516438) started by @bartholomej*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized movie data processing efficiency by streamlining JSON parsing workflow to reduce redundant operations and computational overhead in the data retrieval pipeline.

* **Tests**
  * Updated test suite to align with refactored data processing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->