### PR TITLE
⚡ Bolt: Optimize JSON-LD parsing for movie scraper

### DIFF
--- a/src/helpers/movie.helper.ts
+++ b/src/helpers/movie.helper.ts
@@ -123,23 +123,23 @@ export const getMovieRatingCount = (el: HTMLElement): number => {
   }
 };
 
-export const getMovieYear = (el: string): number => {
-  try {
-    const jsonLd = JSON.parse(el);
+export const getMovieYear = (jsonLd: any): number => {
+  if (jsonLd && jsonLd.dateCreated) {
     return +jsonLd.dateCreated;
-  } catch (error) {
-    console.error('node-csfd-api: Error parsing JSON-LD', error);
-    return null;
   }
+  return null;
 };
 
-export const getMovieDuration = (jsonLdRaw: string, el: HTMLElement): number => {
-  let duration = null;
+export const getMovieDuration = (jsonLd: any, el: HTMLElement): number => {
   try {
-    const jsonLd = JSON.parse(jsonLdRaw);
-    duration = jsonLd.duration;
-    return parseISO8601Duration(duration);
+    if (jsonLd && jsonLd.duration) {
+      return parseISO8601Duration(jsonLd.duration);
+    }
   } catch (error) {
+    // ignore
+  }
+
+  try {
     const origin = el.querySelector('.origin').innerText;
     const timeString = origin.split(',');
     if (timeString.length > 2) {
@@ -151,11 +151,13 @@ export const getMovieDuration = (jsonLdRaw: string, el: HTMLElement): number => 
       const hoursMinsRaw = timeRaw.split('min')[0];
       const hoursMins = hoursMinsRaw.split('h');
       // Resolve hours + minutes format
-      duration = hoursMins.length > 1 ? +hoursMins[0] * 60 + +hoursMins[1] : +hoursMins[0];
+      const duration = hoursMins.length > 1 ? +hoursMins[0] * 60 + +hoursMins[1] : +hoursMins[0];
       return duration;
     } else {
       return null;
     }
+  } catch (e) {
+    return null;
   }
 };
 

--- a/src/services/movie.service.ts
+++ b/src/services/movie.service.ts
@@ -41,7 +41,13 @@ export class MovieScraper {
     const pageClasses = movieHtml.querySelector('.page-content').classNames.split(' ');
     const asideNode = movieHtml.querySelector('.aside-movie-profile');
     const movieNode = movieHtml.querySelector('.main-movie-profile');
-    const jsonLd = movieHtml.querySelector('script[type="application/ld+json"]').innerText;
+    const jsonLdString = movieHtml.querySelector('script[type="application/ld+json"]').innerText;
+    let jsonLd = null;
+    try {
+      jsonLd = JSON.parse(jsonLdString);
+    } catch (e) {
+      console.error('node-csfd-api: Error parsing JSON-LD', e);
+    }
     return this.buildMovie(+movieId, movieNode, asideNode, pageClasses, jsonLd, options);
   }
 
@@ -50,7 +56,7 @@ export class MovieScraper {
     el: HTMLElement,
     asideEl: HTMLElement,
     pageClasses: string[],
-    jsonLd: string,
+    jsonLd: any,
     options: CSFDOptions
   ): CSFDMovie {
     return {

--- a/tests/movie.test.ts
+++ b/tests/movie.test.ts
@@ -48,13 +48,18 @@ const getNode = (node: HTMLElement): HTMLElement => {
   return node.querySelector('.main-movie-profile') as HTMLElement;
 };
 
-const getJsonLd = (node: HTMLElement): string => {
-  return node.querySelector('script[type="application/ld+json"]')?.innerText ?? '{}';
+const getJsonLd = (node: HTMLElement): any => {
+  const json = node.querySelector('script[type="application/ld+json"]')?.innerText || '{}';
+  try {
+    return JSON.parse(json);
+  } catch (e) {
+    return null;
+  }
 };
 
 const getMovie = (
   node: HTMLElement
-): { pClasses: string[]; aside: HTMLElement; pNode: HTMLElement; jsonLd: string } => {
+): { pClasses: string[]; aside: HTMLElement; pNode: HTMLElement; jsonLd: any } => {
   return {
     pClasses: getPageClasses(node),
     aside: getAsideNode(node),


### PR DESCRIPTION
💡 **What:** Refactored `MovieScraper` to parse the JSON-LD metadata string once in the service layer instead of repeatedly parsing it inside helper functions (`getMovieYear` and `getMovieDuration`).
🎯 **Why:** Parsing the same JSON string multiple times is redundant and inefficient.
📊 **Impact:** Reduces JSON parsing operations from O(n) (where n is the number of helpers needing JSON-LD) to O(1) per movie.
🔬 **Measurement:** `yarn test` passes. Verified that `null` JSON-LD is handled gracefully.

---
*PR created automatically by Jules for task [12862088809958610880](https://jules.google.com/task/12862088809958610880) started by @bartholomej*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved robustness of movie metadata extraction with enhanced error handling and safer data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->