### PR TITLE
⚡ Bolt: Parse JSON-LD once in MovieScraper

### DIFF
--- a/src/dto/movie.ts
+++ b/src/dto/movie.ts
@@ -19,6 +19,12 @@ export interface CSFDMovie extends CSFDScreening {
   similar: CSFDMovieListItem[];
 }
 
+export interface MovieJsonLd {
+  dateCreated?: string;
+  duration?: string;
+  [key: string]: any;
+}
+
 export type CSFDVodService =
   | 'Netflix'
   | 'hbogo'

--- a/src/services/movie.service.ts
+++ b/src/services/movie.service.ts
@@ -1,6 +1,6 @@
 import { HTMLElement, parse } from 'node-html-parser';
 import { CSFDFilmTypes } from '../dto/global';
-import { CSFDMovie } from '../dto/movie';
+import { CSFDMovie, MovieJsonLd } from '../dto/movie';
 import { fetchPage } from '../fetchers';
 import {
   getLocalizedCreatorLabel,
@@ -41,7 +41,13 @@ export class MovieScraper {
     const pageClasses = movieHtml.querySelector('.page-content').classNames.split(' ');
     const asideNode = movieHtml.querySelector('.aside-movie-profile');
     const movieNode = movieHtml.querySelector('.main-movie-profile');
-    const jsonLd = movieHtml.querySelector('script[type="application/ld+json"]').innerText;
+    const jsonLdString = movieHtml.querySelector('script[type="application/ld+json"]').innerText;
+    let jsonLd: MovieJsonLd | null = null;
+    try {
+      jsonLd = JSON.parse(jsonLdString);
+    } catch (e) {
+      console.error('node-csfd-api: Error parsing JSON-LD', e);
+    }
     return this.buildMovie(+movieId, movieNode, asideNode, pageClasses, jsonLd, options);
   }
 
@@ -50,7 +56,7 @@ export class MovieScraper {
     el: HTMLElement,
     asideEl: HTMLElement,
     pageClasses: string[],
-    jsonLd: string,
+    jsonLd: MovieJsonLd | null,
     options: CSFDOptions
   ): CSFDMovie {
     return {

--- a/tests/movie.test.ts
+++ b/tests/movie.test.ts
@@ -6,7 +6,8 @@ import {
   CSFDMovieListItem,
   CSFDPremiere,
   CSFDTitlesOther,
-  CSFDVod
+  CSFDVod,
+  MovieJsonLd
 } from '../src/dto/movie';
 import { getColor } from '../src/helpers/global.helper';
 import {
@@ -48,13 +49,18 @@ const getNode = (node: HTMLElement): HTMLElement => {
   return node.querySelector('.main-movie-profile') as HTMLElement;
 };
 
-const getJsonLd = (node: HTMLElement): string => {
-  return node.querySelector('script[type="application/ld+json"]')?.innerText ?? '{}';
+const getJsonLd = (node: HTMLElement): MovieJsonLd | null => {
+  const json = node.querySelector('script[type="application/ld+json"]')?.innerText;
+  try {
+    return json ? JSON.parse(json) : null;
+  } catch (e) {
+    return null;
+  }
 };
 
 const getMovie = (
   node: HTMLElement
-): { pClasses: string[]; aside: HTMLElement; pNode: HTMLElement; jsonLd: string } => {
+): { pClasses: string[]; aside: HTMLElement; pNode: HTMLElement; jsonLd: MovieJsonLd | null } => {
   return {
     pClasses: getPageClasses(node),
     aside: getAsideNode(node),


### PR DESCRIPTION
* 💡 What: Refactored `MovieScraper` to parse JSON-LD string once and pass the parsed object to helper functions `getMovieYear` and `getMovieDuration`.
* 🎯 Why: Previously, `JSON.parse` was called twice for the same JSON-LD string (once for year, once for duration). Parsing JSON is synchronous and can be CPU-intensive for large objects.
* 📊 Impact: Saves 1 redundant `JSON.parse` call per movie scraped. This is a small optimization but adds up when processing many movies.
* 🔬 Measurement: Verify that `getMovieYear` and `getMovieDuration` no longer call `JSON.parse` internally, and `MovieScraper` calls `JSON.parse` exactly once (or zero if missing). Tests in `tests/movie.test.ts` should pass.

---
*PR created automatically by Jules for task [15379557433573781193](https://jules.google.com/task/15379557433573781193) started by @bartholomej*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved movie metadata extraction with enhanced error handling and graceful fallback when encountering incomplete or invalid data
  * Strengthened consistency and reliability of movie information processing throughout the application

* **Tests**
  * Updated tests to validate improved movie data handling and error recovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->