### PR TITLE
⚡ Bolt: Optimize JSON-LD parsing in MovieScraper

### DIFF
--- a/src/dto/movie.ts
+++ b/src/dto/movie.ts
@@ -1,5 +1,11 @@
 import { CSFDScreening } from './global';
 
+export interface MovieJsonLd {
+  dateCreated?: string | number;
+  duration?: string;
+  [key: string]: any;
+}
+
 export interface CSFDMovie extends CSFDScreening {
   rating: number | null;
   poster: string;

--- a/src/services/movie.service.ts
+++ b/src/services/movie.service.ts
@@ -1,6 +1,6 @@
 import { HTMLElement, parse } from 'node-html-parser';
 import { CSFDFilmTypes } from '../dto/global';
-import { CSFDMovie } from '../dto/movie';
+import { CSFDMovie, MovieJsonLd } from '../dto/movie';
 import { fetchPage } from '../fetchers';
 import {
   getLocalizedCreatorLabel,
@@ -41,7 +41,18 @@ export class MovieScraper {
     const pageClasses = movieHtml.querySelector('.page-content').classNames.split(' ');
     const asideNode = movieHtml.querySelector('.aside-movie-profile');
     const movieNode = movieHtml.querySelector('.main-movie-profile');
-    const jsonLd = movieHtml.querySelector('script[type="application/ld+json"]').innerText;
+
+    const jsonLdNode = movieHtml.querySelector('script[type="application/ld+json"]');
+    const jsonLdString = jsonLdNode?.innerText || '';
+    let jsonLd: MovieJsonLd | null = null;
+    if (jsonLdString) {
+      try {
+        jsonLd = JSON.parse(jsonLdString);
+      } catch (e) {
+        console.error('node-csfd-api: Error parsing JSON-LD', e);
+      }
+    }
+
     return this.buildMovie(+movieId, movieNode, asideNode, pageClasses, jsonLd, options);
   }
 
@@ -50,7 +61,7 @@ export class MovieScraper {
     el: HTMLElement,
     asideEl: HTMLElement,
     pageClasses: string[],
-    jsonLd: string,
+    jsonLd: MovieJsonLd | null,
     options: CSFDOptions
   ): CSFDMovie {
     return {


### PR DESCRIPTION
💡 What: Optimized JSON-LD parsing in `MovieScraper` by parsing it once and passing the object to helper functions.
🎯 Why: Previously, `getMovieYear` and `getMovieDuration` both parsed the same JSON-LD string separately, leading to redundant `JSON.parse` calls. Also, accessing `innerText` on a potentially missing script tag could cause a crash.
📊 Impact: Reduces `JSON.parse` calls from 2 to 1 per movie scrape. Improves robustness against missing JSON-LD data.
🔬 Measurement: Verified with `yarn test` (unit tests pass) and `demo.ts` (integration with real CSFD). Verified that `getMovieYear` and `getMovieDuration` handle both string (legacy/test) and object (optimized) inputs.

---
*PR created automatically by Jules for task [13739219483204995619](https://jules.google.com/task/13739219483204995619) started by @bartholomej*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced movie metadata extraction with improved error handling and structured data processing for movie duration and year information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->