### PR TITLE
⚡ Bolt: Parse JSON-LD once in MovieScraper

### DIFF
--- a/src/helpers/movie.helper.ts
+++ b/src/helpers/movie.helper.ts
@@ -15,6 +15,12 @@ import {
 } from '../dto/movie';
 import { addProtocol, getColor, parseISO8601Duration, parseIdFromUrl } from './global.helper';
 
+export interface MovieJsonLd {
+  dateCreated?: string;
+  duration?: string;
+  [key: string]: any;
+}
+
 /**
  * Maps language-specific movie creator group labels.
  * @param language - The language code (e.g., 'en', 'cs')
@@ -123,9 +129,14 @@ export const getMovieRatingCount = (el: HTMLElement): number => {
   }
 };
 
-export const getMovieYear = (el: string): number => {
+export const getMovieYear = (el: string | MovieJsonLd | null): number => {
+  let jsonLd: MovieJsonLd;
   try {
-    const jsonLd = JSON.parse(el);
+    if (typeof el === 'string') {
+      jsonLd = JSON.parse(el);
+    } else {
+      jsonLd = el;
+    }
     return +jsonLd.dateCreated;
   } catch (error) {
     console.error('node-csfd-api: Error parsing JSON-LD', error);
@@ -133,11 +144,19 @@ export const getMovieYear = (el: string): number => {
   }
 };
 
-export const getMovieDuration = (jsonLdRaw: string, el: HTMLElement): number => {
+export const getMovieDuration = (jsonLdRaw: string | MovieJsonLd | null, el: HTMLElement): number => {
   let duration = null;
   try {
-    const jsonLd = JSON.parse(jsonLdRaw);
+    let jsonLd: MovieJsonLd;
+    if (typeof jsonLdRaw === 'string') {
+      jsonLd = JSON.parse(jsonLdRaw);
+    } else {
+      jsonLd = jsonLdRaw;
+    }
     duration = jsonLd.duration;
+    if (!duration) {
+      throw new Error('Duration not found in JSON-LD');
+    }
     return parseISO8601Duration(duration);
   } catch (error) {
     const origin = el.querySelector('.origin').innerText;

--- a/src/services/movie.service.ts
+++ b/src/services/movie.service.ts
@@ -22,7 +22,8 @@ import {
   getMovieTrivia,
   getMovieType,
   getMovieVods,
-  getMovieYear
+  getMovieYear,
+  MovieJsonLd
 } from '../helpers/movie.helper';
 import { CSFDOptions } from '../types';
 import { movieUrl } from '../vars';
@@ -41,8 +42,14 @@ export class MovieScraper {
     const pageClasses = movieHtml.querySelector('.page-content').classNames.split(' ');
     const asideNode = movieHtml.querySelector('.aside-movie-profile');
     const movieNode = movieHtml.querySelector('.main-movie-profile');
-    const jsonLd = movieHtml.querySelector('script[type="application/ld+json"]').innerText;
-    return this.buildMovie(+movieId, movieNode, asideNode, pageClasses, jsonLd, options);
+    const jsonLdString = movieHtml.querySelector('script[type="application/ld+json"]')?.innerText;
+    let jsonLd: MovieJsonLd = null;
+    try {
+      jsonLd = JSON.parse(jsonLdString);
+    } catch (e) {
+      // Error parsing JSON-LD
+    }
+    return this.buildMovie(+movieId, movieNode, asideNode, pageClasses, jsonLd || jsonLdString, options);
   }
 
   private buildMovie(
@@ -50,7 +57,7 @@ export class MovieScraper {
     el: HTMLElement,
     asideEl: HTMLElement,
     pageClasses: string[],
-    jsonLd: string,
+    jsonLd: string | MovieJsonLd,
     options: CSFDOptions
   ): CSFDMovie {
     return {


### PR DESCRIPTION
💡 What: Refactored `MovieScraper.movie` to parse the JSON-LD script content once and pass the resulting object to `getMovieYear` and `getMovieDuration` helpers.
🎯 Why: Previously, `JSON.parse` was called redundantly for each helper, causing unnecessary overhead.
📊 Impact: Reduces CPU usage during scraping of movie pages by eliminating duplicate JSON parsing.
🔬 Measurement: Verified by running `yarn test` and ensuring all tests pass, including those covering `getMovieYear` and `getMovieDuration`.

---
*PR created automatically by Jules for task [166927608926119675](https://jules.google.com/task/166927608926119675) started by @bartholomej*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced movie metadata extraction to support flexible data formats
  * Improved parsing and retrieval of movie year and duration information
  * Better error handling for movie data processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->