### PR TITLE
refactor: replace any[] with RegExpMatchArray in getDuration

### DIFF
--- a/src/helpers/global.helper.ts
+++ b/src/helpers/global.helper.ts
@@ -46,7 +46,7 @@ export const addProtocol = (url: string): string => {
   return url.startsWith('//') ? 'https:' + url : url;
 };
 
-export const getDuration = (matches: any[]) => {
+export const getDuration = (matches: RegExpMatchArray) => {
   return {
     sign: matches[1] === undefined ? '+' : '-',
     years: matches[2] === undefined ? 0 : matches[2],

--- a/tests/global.test.ts
+++ b/tests/global.test.ts
@@ -11,10 +11,7 @@ export const durationInput = [
   undefined,
   undefined,
   '142',
-  undefined,
-  { index: 0 },
-  { input: 'PT142M' },
-  { groups: undefined }
+  undefined
 ];
 
 const result = {
@@ -30,7 +27,7 @@ const result = {
 
 describe('Live: Fetch rating page', () => {
   test('Resolve duration', async () => {
-    const resolver = getDuration(durationInput);
+    const resolver = getDuration(durationInput as RegExpMatchArray);
     expect(resolver).toEqual(result);
   });
 });


### PR DESCRIPTION
Replaced `any[]` with `RegExpMatchArray` in `getDuration` helper for better type safety. Updated the corresponding test case to fix invalid mock data.

---
*PR created automatically by Jules for task [4073786381170705039](https://jules.google.com/task/4073786381170705039) started by @bartholomej*