### PR TITLE
feat: normalize film type values and parsing [breaking]

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ console.log(results.users); // Array of users
     title: 'Black Bart',
     year: '1975',
     url: 'https://www.csfd.cz/film/19653-black-bart/',
-    type: 'TV film',
+    type: 'tv-film',
     colorRating: 'bad',
     poster: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
     origins: ['USA'],
@@ -247,7 +247,7 @@ tvSeries: [
     title: 'Království',
     year: 1994,
     url: 'https://www.csfd.cz/film/71924-kralovstvi/',
-    type: 'seriál',
+    type: 'series',
     colorRating: 'good',
     poster: 'https://image.pmgstatic.com/cache/resized/w60h85/files/images/film/posters/166/708/166708064_2da697.jpg',
     origins: ['Dánsko'],
@@ -398,7 +398,7 @@ const onlyMovies = await csfd.userRatings('912-bart', {
 });
 
 const excludeEpisodes = await csfd.userRatings('912-bart', {
-  exclude: ['epizoda', 'série']
+  exclude: ['episode', 'season']
 });
 ```
 
@@ -434,13 +434,13 @@ const excludeEpisodes = await csfd.userRatings('912-bart', {
 
 #### UserRatingsOptions
 
-| Option          | Type              | Default | Description                                                      |
-| --------------- | ----------------- | ------- | ---------------------------------------------------------------- |
-| `includesOnly`  | `CSFDFilmTypes[]` | `null`  | Include only specific content types (e.g., `['film', 'seriál']`) |
-| `exclude`       | `CSFDFilmTypes[]` | `null`  | Exclude specific content types (e.g., `['epizoda']`)             |
-| `allPages`      | `boolean`         | `false` | Fetch all pages of ratings                                       |
-| `allPagesDelay` | `number`          | `0`     | Delay between page requests in milliseconds                      |
-| `page`          | `number`          | `1`     | Fetch specific page number                                       |
+| Option          | Type              | Default | Description                                                          |
+| --------------- | ----------------- | ------- | -------------------------------------------------------------------- |
+| `includesOnly`  | `CSFDFilmTypes[]` | `null`  | Include only specific content types (e.g., `['film', 'series']`) |
+| `exclude`       | `CSFDFilmTypes[]` | `null`  | Exclude specific content types (e.g., `['episode']`)                 |
+| `allPages`      | `boolean`         | `false` | Fetch all pages of ratings                                           |
+| `allPagesDelay` | `number`          | `0`     | Delay between page requests in milliseconds                          |
+| `page`          | `number`          | `1`     | Fetch specific page number                                           |
 
 > 📝 **Note**: `includesOnly` and `exclude` are mutually exclusive. If both are provided, `includesOnly` takes precedence.
 >
@@ -476,7 +476,7 @@ const allReviews = await csfd.userReviews(195357, {
 // Filter by content type
 const filtered = await csfd.userReviews(195357, {
   includesOnly: ['film'],
-  exclude: ['epizoda']
+  exclude: ['episode']
 });
 ```
 

--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -118,7 +118,7 @@ server.tool(
     excludes: z
       .array(z.string())
       .optional()
-      .describe('Film types to exclude (e.g. "seriál", "TV film")'),
+      .describe('Film types to exclude (e.g. "series", "tv-film")'),
     includesOnly: z
       .array(z.string())
       .optional()
@@ -168,7 +168,7 @@ server.tool(
     excludes: z
       .array(z.string())
       .optional()
-      .describe('Film types to exclude (e.g. "seriál", "TV film")'),
+      .describe('Film types to exclude (e.g. "series", "tv-film")'),
     includesOnly: z
       .array(z.string())
       .optional()

--- a/src/dto/global.ts
+++ b/src/dto/global.ts
@@ -24,13 +24,14 @@ export type CSFDStars = 0 | 1 | 2 | 3 | 4 | 5;
 
 export type CSFDFilmTypes =
   | 'film'
-  | 'TV film'
-  | 'pořad'
-  | 'seriál'
-  | 'divadelní záznam'
-  | 'koncert'
-  | 'série'
-  | 'studentský film'
-  | 'amatérský film'
-  | 'hudební videoklip'
-  | 'epizoda';
+  | 'tv-film'
+  | 'tv-show'
+  | 'series'
+  | 'theatrical'
+  | 'concert'
+  | 'season'
+  | 'student-film'
+  | 'amateur-film'
+  | 'music-video'
+  | 'episode'
+  | 'video-compilation';

--- a/src/helpers/global.helper.ts
+++ b/src/helpers/global.helper.ts
@@ -1,4 +1,4 @@
-import { CSFDColorRating } from '../dto/global';
+import { CSFDColorRating, CSFDFilmTypes } from '../dto/global';
 import { CSFDColors } from '../dto/user-ratings';
 
 const LANG_PREFIX_REGEX = /^[a-z]{2,3}$/;
@@ -44,6 +44,25 @@ export const parseColor = (quality: CSFDColors): CSFDColorRating => {
     default:
       return 'unknown';
   }
+};
+
+const filmTypeMap: Record<string, CSFDFilmTypes> = {
+  'TV film': 'tv-film',
+  pořad: 'tv-show',
+  seriál: 'series',
+  'divadelní záznam': 'theatrical',
+  koncert: 'concert',
+  série: 'season',
+  'studentský film': 'student-film',
+  'amatérský film': 'amateur-film',
+  'hudební videoklip': 'music-video',
+  epizoda: 'episode',
+  'video kompilace': 'video-compilation',
+  film: 'film'
+};
+
+export const parseFilmType = (type: string): CSFDFilmTypes => {
+  return filmTypeMap[type] || 'film';
 };
 
 export const addProtocol = (url: string): string => {

--- a/src/helpers/movie.helper.ts
+++ b/src/helpers/movie.helper.ts
@@ -1,5 +1,5 @@
 import { HTMLElement } from 'node-html-parser';
-import { CSFDColorRating } from '../dto/global';
+import { CSFDColorRating, CSFDFilmTypes } from '../dto/global';
 import {
   CSFDBoxContent,
   CSFDCreatorGroups,
@@ -20,6 +20,7 @@ import {
   addProtocol,
   getColor,
   parseDate,
+  parseFilmType,
   parseISO8601Duration,
   parseIdFromUrl
 } from './global.helper';
@@ -327,9 +328,9 @@ export const getMovieCreators = (el: HTMLElement, options?: CSFDOptions): CSFDCr
   return creators;
 };
 
-export const getMovieType = (el: HTMLElement): string => {
+export const getMovieType = (el: HTMLElement): CSFDFilmTypes => {
   const type = el.querySelector('.film-header-name .type');
-  return type?.innerText?.replace(/[{()}]/g, '') || 'film';
+  return parseFilmType(type?.innerText?.replace(/[{()}]/g, '') || 'film');
 };
 
 export const getMovieVods = (el: HTMLElement | null): CSFDVod[] => {

--- a/src/helpers/search.helper.ts
+++ b/src/helpers/search.helper.ts
@@ -2,13 +2,13 @@ import { HTMLElement } from 'node-html-parser';
 import { CSFDColorRating, CSFDFilmTypes } from '../dto/global';
 import { CSFDMovieCreator } from '../dto/movie';
 import { CSFDColors } from '../dto/user-ratings';
-import { addProtocol, parseColor, parseIdFromUrl } from './global.helper';
+import { addProtocol, parseColor, parseFilmType, parseIdFromUrl } from './global.helper';
 
 type Creator = 'Režie:' | 'Hrají:';
 
 export const getSearchType = (el: HTMLElement): CSFDFilmTypes => {
   const type = el.querySelectorAll('.film-title-info .info')[1];
-  return (type?.innerText?.replace(/[{()}]/g, '')?.trim() || 'film') as CSFDFilmTypes;
+  return parseFilmType(type?.innerText?.replace(/[{()}]/g, '')?.trim() || 'film');
 };
 
 export const getSearchTitle = (el: HTMLElement): string => {
@@ -41,7 +41,10 @@ export const getSearchOrigins = (el: HTMLElement): string[] => {
   return originsAll?.split('/').map((country) => country.trim());
 };
 
-export const parseSearchPeople = (el: HTMLElement, type: 'directors' | 'actors'): CSFDMovieCreator[] => {
+export const parseSearchPeople = (
+  el: HTMLElement,
+  type: 'directors' | 'actors'
+): CSFDMovieCreator[] => {
   let who: Creator;
   if (type === 'directors') who = 'Režie:';
   if (type === 'actors') who = 'Hrají:';

--- a/src/helpers/user-ratings.helper.ts
+++ b/src/helpers/user-ratings.helper.ts
@@ -1,7 +1,7 @@
 import { HTMLElement } from 'node-html-parser';
 import { CSFDColorRating, CSFDFilmTypes, CSFDStars } from '../dto/global';
 import { CSFDColors } from '../dto/user-ratings';
-import { parseColor, parseIdFromUrl } from './global.helper';
+import { parseColor, parseFilmType, parseIdFromUrl } from './global.helper';
 
 export const getUserRatingId = (el: HTMLElement): number => {
   const url = el.querySelector('td.name .film-title-name').attributes.href;
@@ -18,7 +18,7 @@ export const getUserRating = (el: HTMLElement): CSFDStars => {
 export const getUserRatingType = (el: HTMLElement): CSFDFilmTypes => {
   const typeText = el.querySelectorAll('td.name .film-title-info .info');
 
-  return (typeText.length > 1 ? typeText[1].text : 'film') as CSFDFilmTypes;
+  return parseFilmType(typeText.length > 1 ? typeText[1].text : 'film');
 };
 
 export const getUserRatingTitle = (el: HTMLElement): string => {

--- a/src/helpers/user-reviews.helper.ts
+++ b/src/helpers/user-reviews.helper.ts
@@ -1,7 +1,7 @@
 import { HTMLElement } from 'node-html-parser';
 import { CSFDColorRating, CSFDFilmTypes, CSFDStars } from '../dto/global';
 import { CSFDColors } from '../dto/user-ratings';
-import { parseColor, parseDate, parseIdFromUrl } from './global.helper';
+import { parseColor, parseDate, parseFilmType, parseIdFromUrl } from './global.helper';
 
 export const getUserReviewId = (el: HTMLElement): number => {
   const url = el.querySelector('.film-title-name').attributes.href;
@@ -19,7 +19,7 @@ export const getUserReviewType = (el: HTMLElement): CSFDFilmTypes => {
   // Type can be in the second .info span (e.g., "(seriál)") // TODO need more tests
   const typeText = el.querySelectorAll('.film-title-info .info');
 
-  return (typeText.length > 1 ? typeText[1].text.slice(1, -1) : 'film') as CSFDFilmTypes;
+  return parseFilmType(typeText.length > 1 ? typeText[1].text.slice(1, -1) : 'film');
 };
 
 export const getUserReviewTitle = (el: HTMLElement): string => {

--- a/tests/fetchers.test.ts
+++ b/tests/fetchers.test.ts
@@ -168,7 +168,7 @@ describe('Live: Tv series', () => {
     expect(movie.year).toEqual<number>(1994);
   });
   test('Type', () => {
-    expect(movie.type).toEqual<CSFDFilmTypes>('seriál');
+    expect(movie.type).toEqual<CSFDFilmTypes>('series');
   });
   test('Title', () => {
     expect(movie.title).toEqual<string>('Království');

--- a/tests/movie.test.ts
+++ b/tests/movie.test.ts
@@ -1,6 +1,6 @@
 import { HTMLElement, parse } from 'node-html-parser';
 import { describe, expect, test } from 'vitest';
-import { CSFDColorRating } from '../src/dto/global';
+import { CSFDColorRating, CSFDFilmTypes } from '../src/dto/global';
 import {
   CSFDMovieCreator,
   CSFDMovieListItem,
@@ -360,15 +360,15 @@ describe('Get genres', () => {
 describe('Get type', () => {
   test('Type', () => {
     const movie = getMovieType(movieNode);
-    expect(movie).toEqual<string>('film');
+    expect(movie).toEqual<CSFDFilmTypes>('film');
   });
   test('Type Rich', () => {
     const movie = getMovieType(movieNodeRich);
-    expect(movie).toEqual<string>('film');
+    expect(movie).toEqual<CSFDFilmTypes>('film');
   });
   test('Type Series', () => {
     const movie = getMovieType(seriesNode);
-    expect(movie).toEqual<string>('seriál');
+    expect(movie).toEqual<CSFDFilmTypes>('series');
   });
 });
 

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -226,15 +226,15 @@ describe('Get TV series url', () => {
 describe('Get TV series types', () => {
   test('First TV series', () => {
     const movie = getSearchType(tvSeriesNode[0]);
-    expect(movie).toEqual<CSFDFilmTypes>('seriál');
+    expect(movie).toEqual<CSFDFilmTypes>('series');
   });
   test('Last TV series', () => {
     const movie = getSearchType(tvSeriesNode[tvSeriesNode.length - 1]);
-    expect(movie).toEqual<CSFDFilmTypes>('epizoda');
+    expect(movie).toEqual<CSFDFilmTypes>('episode');
   });
   test('Some TV series', () => {
     const movie = getSearchType(tvSeriesNode[1]);
-    expect(movie).toEqual<CSFDFilmTypes>('seriál');
+    expect(movie).toEqual<CSFDFilmTypes>('series');
   });
 });
 

--- a/tests/user-ratings.service.test.ts
+++ b/tests/user-ratings.service.test.ts
@@ -50,23 +50,23 @@ describe('Filter out episodes, TV Series and Seasons', () => {
   // Fetch data with excludes
   const userRatingsScraper = new UserRatingsScraper();
   const resExcluded: Promise<CSFDUserRatings[]> = userRatingsScraper.userRatings(USER, {
-    excludes: ['epizoda', 'seriál', 'série']
+    excludes: ['episode', 'series', 'season']
   });
 
   test('Should not have any episode', async () => {
     const results = await resExcluded;
 
-    const episodes = results.filter((item) => item.type === 'epizoda');
+    const episodes = results.filter((item) => item.type === 'episode');
     expect(episodes.length).toBe<number>(0);
   });
   test('Should not have any TV series', async () => {
     const results = await resExcluded;
-    const tvSeries = results.filter((item) => item.type === 'seriál');
+    const tvSeries = results.filter((item) => item.type === 'series');
     expect(tvSeries.length).toBe<number>(0);
   });
   test('Should not have any Season', async () => {
     const results = await resExcluded;
-    const season = results.filter((item) => item.type === 'série');
+    const season = results.filter((item) => item.type === 'season');
     expect(season.length).toBe<number>(0);
   });
 });
@@ -75,7 +75,7 @@ describe('Includes only TV series or Episodes or something...', () => {
   // Fetch data with excludes
   const userRatingsScraper = new UserRatingsScraper();
   const resIncluded: Promise<CSFDUserRatings[]> = userRatingsScraper.userRatings(USER, {
-    includesOnly: ['epizoda']
+    includesOnly: ['episode']
   });
 
   test('Should not have any film', async () => {
@@ -88,13 +88,13 @@ describe('Includes only TV series or Episodes or something...', () => {
     const results = await resIncluded;
     console.log(results);
 
-    const tvSeries = results.filter((item) => item.type === 'epizoda');
+    const tvSeries = results.filter((item) => item.type === 'episode');
     expect(tvSeries.length).toBeGreaterThan(0);
   });
   test('Should have only TV series', async () => {
     const results = await resIncluded;
 
-    const tvSeries = results.filter((item) => item.type === 'epizoda');
+    const tvSeries = results.filter((item) => item.type === 'episode');
     expect(tvSeries.length).toBe(results.length);
   });
 });
@@ -103,7 +103,7 @@ describe('Exclude + includes together', () => {
   // Fetch data with excludes + includes
   const userRatingsScraper = new UserRatingsScraper();
   const resBoth: Promise<CSFDUserRatings[]> = userRatingsScraper.userRatings(USER, {
-    includesOnly: ['seriál'],
+    includesOnly: ['series'],
     excludes: ['film']
   });
 
@@ -114,7 +114,7 @@ describe('Exclude + includes together', () => {
   test('Should use includesOnly', async () => {
     const results = await resBoth;
 
-    const tvSeries = results.filter((item) => item.type === 'seriál');
+    const tvSeries = results.filter((item) => item.type === 'series');
     expect(tvSeries.length).toBe<number>(results.length);
   });
 });

--- a/tests/user-ratings.test.ts
+++ b/tests/user-ratings.test.ts
@@ -71,27 +71,27 @@ describe('Get type', () => {
   });
   test('TV series', () => {
     const movie = getUserRatingType(movies[2]);
-    expect(movie).toEqual<CSFDFilmTypes>('seriál');
+    expect(movie).toEqual<CSFDFilmTypes>('series');
   });
   test('Episode', () => {
     const movie = getUserRatingType(movies[5]);
-    expect(movie).toEqual<CSFDFilmTypes>('epizoda');
+    expect(movie).toEqual<CSFDFilmTypes>('episode');
   });
   // test('TV film', () => {
   //   const movie = getUserRatingType(movies[18]);
-  //   expect(movie).toEqual<CSFDFilmTypes>('TV film');
+  //   expect(movie).toEqual<CSFDFilmTypes>('tv-film');
   // });
   // test('Pořad', () => {
   //   const movie = getUserRatingType(movies[6]);
-  //   expect(movie).toEqual<CSFDFilmTypes>('pořad');
+  //   expect(movie).toEqual<CSFDFilmTypes>('tv-show');
   // });
   // test('Amateur film', () => {
   //   const movie = getUserRatingType(movies[31]);
-  //   expect(movie).toEqual<CSFDFilmTypes>('amatérský film');
+  //   expect(movie).toEqual<CSFDFilmTypes>('amateur-film');
   // });
   // test('Season', () => {
   //   const movie = getUserRatingType(movies[11]);
-  //   expect(movie).toEqual<CSFDFilmTypes>('série');
+  //   expect(movie).toEqual<CSFDFilmTypes>('season');
   // });
 });
 

--- a/tests/user-reviews.service.test.ts
+++ b/tests/user-reviews.service.test.ts
@@ -64,7 +64,7 @@ describe('User Reviews - Filter by type', () => {
 
   test('Should not have any TV series', async () => {
     const results = await resFilmsOnly;
-    const tvSeries = results.filter((item) => item.type === 'seriál');
+    const tvSeries = results.filter((item) => item.type === 'series');
     expect(tvSeries.length).toBe<number>(0);
   });
 });
@@ -74,13 +74,13 @@ describe('User Reviews - Exclude types', () => {
   const resExcluded: Promise<CSFDUserReviews[]> = userReviewsScraper.userReviews(
     USER_WITH_REVIEWS,
     {
-      excludes: ['seriál']
+      excludes: ['series']
     }
   );
 
   test('Should not have any TV series', async () => {
     const results = await resExcluded;
-    const tvSeries = results.filter((item) => item.type === 'seriál');
+    const tvSeries = results.filter((item) => item.type === 'series');
     expect(tvSeries.length).toBe<number>(0);
   });
 });
@@ -132,7 +132,7 @@ describe('User Reviews - Exclude + includes together (warning)', () => {
   const userReviewsScraper = new UserReviewsScraper();
   const resBoth: Promise<CSFDUserReviews[]> = userReviewsScraper.userReviews(USER_WITH_REVIEWS, {
     includesOnly: ['film'],
-    excludes: ['seriál']
+    excludes: ['series']
   });
 
   test('Should have warning', () => {


### PR DESCRIPTION
## Description

Breaking change

Standardize film type identifiers to English values across the codebase. Introduces CSFDFilmTypes updated to English keys (e.g. 'film' -> 'movie', 'seriál' -> 'tv-series', 'TV film' -> 'tv-movie', 'epizoda' -> 'episode', plus others), adds parseFilmType helper to map Czech/raw strings to the new enum, and updates all helpers, server tool descriptions, demo, README examples, and tests to use the new values. Tests and parsing now rely on parseFilmType for consistent type normalization.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with English film type examples and API descriptions
  * Film type values standardized to English terminology (e.g., series, episode, season)

* **Bug Fixes**
  * Improved film type validation and mapping with consistent English naming conventions

* **Tests**
  * Updated test cases to reflect standardized film type values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->