### PR TITLE
⚡ Bolt: [performance improvement] Optimize DOM queries by replacing querySelectorAll with querySelector

### DIFF
--- a/src/helpers/creator.helper.ts
+++ b/src/helpers/creator.helper.ts
@@ -61,7 +61,8 @@ const parseAge = (text: string): number | null => {
 const parseBirthPlace = (text: string): string => text.trim().replace(/<br>/g, '').trim();
 
 export const getCreatorFilms = (el: HTMLElement | null): CSFDCreatorScreening[] => {
-  const filmNodes = el?.querySelectorAll('.updated-box')?.[0]?.querySelectorAll('table tr') ?? [];
+  // Optimization: Use querySelector instead of querySelectorAll(...)[0]
+  const filmNodes = el?.querySelector('.updated-box')?.querySelectorAll('table tr') ?? [];
   let yearCache: number | null = null;
 
   const films = filmNodes.map((filmNode) => {

--- a/src/helpers/search.helper.ts
+++ b/src/helpers/search.helper.ts
@@ -16,7 +16,8 @@ export const getSearchTitle = (el: HTMLElement): string => {
 };
 
 export const getSearchYear = (el: HTMLElement): number => {
-  return +el.querySelectorAll('.film-title-info .info')[0]?.innerText.replace(/[{()}]/g, '');
+  // Optimization: Use querySelector instead of querySelectorAll(...)[0]
+  return +el.querySelector('.film-title-info .info')?.innerText.replace(/[{()}]/g, '');
 };
 
 export const getSearchUrl = (el: HTMLElement): string => {


### PR DESCRIPTION
💡 What: Replaced instances of `.querySelectorAll(...)[0]` with `.querySelector(...)` in `src/helpers/search.helper.ts` and `src/helpers/creator.helper.ts`.

🎯 Why: `querySelectorAll` forces `node-html-parser` to traverse the entire DOM tree (or subtree) to find all matching elements. Since we only need the first element, using `querySelector` allows the parser to exit early, reducing computation and memory allocation overhead during page scraping operations.

📊 Impact: Reduces unneeded DOM traversals and parsing overhead on large node lists when extracting search results or creator films.

🔬 Measurement: Verify tests continue to pass with `yarn test`. Check scrape times of heavily nested `search` and `creator` endpoints for slight parsing speedups.

---
*PR created automatically by Jules for task [2569460772961453041](https://jules.google.com/task/2569460772961453041) started by @bartholomej*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized query selector usage in helper utilities for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->