### PR TITLE
⚡ Bolt: [performance improvement] avoid intermediate arrays in parseSearchPeople

### DIFF
--- a/src/helpers/search.helper.ts
+++ b/src/helpers/search.helper.ts
@@ -50,12 +50,13 @@ export const parseSearchPeople = (
   if (type === 'directors') who = 'Režie:';
   if (type === 'actors') who = 'Hrají:';
 
-  const peopleNode = Array.from(el && el.querySelectorAll('.article-content p')).find((el) =>
-    el.textContent.includes(who)
-  );
+  // Optimization: querySelectorAll returns an array in node-html-parser, no need for Array.from()
+  const peopleNode = el
+    ?.querySelectorAll('.article-content p')
+    ?.find((el) => el.textContent.includes(who));
 
   if (peopleNode) {
-    const people = Array.from(peopleNode.querySelectorAll('a')) as unknown as HTMLElement[];
+    const people = peopleNode.querySelectorAll('a');
 
     return people.map((person) => {
       return {


### PR DESCRIPTION
💡 What: Replace `Array.from().find()` with `.find()` on `node-html-parser` arrays, and map directly over `querySelectorAll` result.
🎯 Why: Avoids unnecessary allocation of intermediate arrays when searching for creator paragraphs and parsing person links.
📊 Impact: Lowers memory overhead and slightly improves execution speed.
🔬 Measurement: Run `bun test` to confirm.

---
*PR created automatically by Jules for task [3772258637480593546](https://jules.google.com/task/3772258637480593546) started by @bartholomej*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code handling for search functionality to enhance robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->