### PR TITLE
🛠️ DX: [flexible ID parsing for APIs]

### DIFF
--- a/src/helpers/global.helper.ts
+++ b/src/helpers/global.helper.ts
@@ -5,6 +5,27 @@ const LANG_PREFIX_REGEX = /^[a-z]{2,3}$/;
 const ISO8601_DURATION_REGEX =
   /(-)?P(?:([.,\d]+)Y)?(?:([.,\d]+)M)?(?:([.,\d]+)W)?(?:([.,\d]+)D)?T(?:([.,\d]+)H)?(?:([.,\d]+)M)?(?:([.,\d]+)S)?/;
 
+export const extractId = (id: string | number): number | null => {
+  if (typeof id === 'number') {
+    return id;
+  }
+
+  if (typeof id === 'string') {
+    let parsedId: number | null = null;
+    if (id.includes('/')) {
+      parsedId = parseIdFromUrl(id);
+    } else {
+      parsedId = +id.split('-')[0];
+    }
+
+    if (parsedId !== null && !isNaN(parsedId)) {
+      return parsedId;
+    }
+  }
+
+  return null;
+};
+
 export const parseIdFromUrl = (url: string): number => {
   if (!url) return null;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,14 +54,14 @@ export class Csfd {
     return this.userReviewsService.userReviews(user, config, opts);
   }
 
-  public async movie(movie: number, options?: CSFDOptions): Promise<CSFDMovie> {
+  public async movie(movie: number | string, options?: CSFDOptions): Promise<CSFDMovie> {
     const opts = options ?? this.defaultOptions;
-    return this.movieService.movie(+movie, opts);
+    return this.movieService.movie(movie, opts);
   }
 
-  public async creator(creator: number, options?: CSFDOptions): Promise<CSFDCreator> {
+  public async creator(creator: number | string, options?: CSFDOptions): Promise<CSFDCreator> {
     const opts = options ?? this.defaultOptions;
-    return this.creatorService.creator(+creator, opts);
+    return this.creatorService.creator(creator, opts);
   }
 
   public async search(text: string, options?: CSFDOptions): Promise<CSFDSearch> {

--- a/src/services/creator.service.ts
+++ b/src/services/creator.service.ts
@@ -1,6 +1,7 @@
 import { HTMLElement, parse } from 'node-html-parser';
 import { CSFDCreator } from '../dto/creator';
 import { fetchPage } from '../fetchers';
+import { extractId } from '../helpers/global.helper';
 import {
   getCreatorBio,
   getCreatorBirthdayInfo,
@@ -12,10 +13,10 @@ import { CSFDOptions } from '../types';
 import { creatorUrl } from '../vars';
 
 export class CreatorScraper {
-  public async creator(creatorId: number, options?: CSFDOptions): Promise<CSFDCreator> {
-    const id = Number(creatorId);
-    if (isNaN(id)) {
-      throw new Error('node-csfd-api: creatorId must be a valid number');
+  public async creator(creatorId: number | string, options?: CSFDOptions): Promise<CSFDCreator> {
+    const id = extractId(creatorId);
+    if (id === null || isNaN(id)) {
+      throw new Error('node-csfd-api: creatorId could not be extracted. Provide a valid number, numeric string, slug, or URL.');
     }
     const url = creatorUrl(id, { language: options?.language });
     const response = await fetchPage(url, { ...options?.request });
@@ -24,7 +25,7 @@ export class CreatorScraper {
 
     const asideNode = creatorHtml.querySelector('.creator-about');
     const filmsNode = creatorHtml.querySelector('.creator-filmography');
-    return this.buildCreator(+creatorId, asideNode, filmsNode);
+    return this.buildCreator(id, asideNode, filmsNode);
   }
 
   private buildCreator(id: number, asideEl: HTMLElement, filmsNode: HTMLElement): CSFDCreator {

--- a/src/services/movie.service.ts
+++ b/src/services/movie.service.ts
@@ -2,6 +2,7 @@ import { HTMLElement, parse } from 'node-html-parser';
 import { CSFDFilmTypes } from '../dto/global';
 import { CSFDMovie, MovieJsonLd } from '../dto/movie';
 import { fetchPage } from '../fetchers';
+import { extractId } from '../helpers/global.helper';
 import {
   detectSeasonOrEpisodeListType,
   getEpisodeCode,
@@ -32,10 +33,10 @@ import { CSFDOptions } from '../types';
 import { LIB_PREFIX, movieUrl } from '../vars';
 
 export class MovieScraper {
-  public async movie(movieId: number, options?: CSFDOptions): Promise<CSFDMovie> {
-    const id = Number(movieId);
-    if (isNaN(id)) {
-      throw new Error('node-csfd-api: movieId must be a valid number');
+  public async movie(movieId: number | string, options?: CSFDOptions): Promise<CSFDMovie> {
+    const id = extractId(movieId);
+    if (id === null || isNaN(id)) {
+      throw new Error('node-csfd-api: movieId could not be extracted. Provide a valid number, numeric string, slug, or URL.');
     }
     const url = movieUrl(id, { language: options?.language });
     const response = await fetchPage(url, { ...options?.request });
@@ -52,7 +53,7 @@ export class MovieScraper {
     } catch (e) {
       console.error(LIB_PREFIX + ' Error parsing JSON-LD', e);
     }
-    return this.buildMovie(+movieId, movieHtml, movieNode as HTMLElement, asideNode as HTMLElement, pageClasses, jsonLd, options);
+    return this.buildMovie(id, movieHtml, movieNode as HTMLElement, asideNode as HTMLElement, pageClasses, jsonLd, options);
   }
 
   private buildMovie(

--- a/src/services/user-ratings.service.ts
+++ b/src/services/user-ratings.service.ts
@@ -2,7 +2,7 @@ import { HTMLElement, parse } from 'node-html-parser';
 import { CSFDColorRating, CSFDFilmTypes, CSFDStars } from '../dto/global';
 import { CSFDUserRatingConfig, CSFDUserRatings } from '../dto/user-ratings';
 import { fetchPage } from '../fetchers';
-import { sleep } from '../helpers/global.helper';
+import { extractId, sleep } from '../helpers/global.helper';
 import {
   getUserRating,
   getUserRatingColorRating,
@@ -22,9 +22,14 @@ export class UserRatingsScraper {
     config?: CSFDUserRatingConfig,
     options?: CSFDOptions
   ): Promise<CSFDUserRatings[]> {
+    const id = extractId(user);
+    if (id === null || isNaN(id)) {
+      throw new Error('node-csfd-api: user could not be extracted. Provide a valid number, numeric string, slug, or URL.');
+    }
+
     let allMovies: CSFDUserRatings[] = [];
     const pageToFetch = config?.page || 1;
-    const url = userRatingsUrl(user, pageToFetch > 1 ? pageToFetch : undefined, {
+    const url = userRatingsUrl(id, pageToFetch > 1 ? pageToFetch : undefined, {
       language: options?.language
     });
     const response = await fetchPage(url, { ...options?.request });
@@ -40,7 +45,7 @@ export class UserRatingsScraper {
     if (config?.allPages) {
       for (let i = 2; i <= pages; i++) {
         config.onProgress?.(i, pages);
-        const url = userRatingsUrl(user, i, { language: options?.language });
+        const url = userRatingsUrl(id, i, { language: options?.language });
         const response = await fetchPage(url, { ...options?.request });
 
         const items = parse(response);

--- a/src/services/user-reviews.service.ts
+++ b/src/services/user-reviews.service.ts
@@ -2,7 +2,7 @@ import { HTMLElement, parse } from 'node-html-parser';
 import { CSFDColorRating, CSFDFilmTypes, CSFDStars } from '../dto/global';
 import { CSFDUserReviews, CSFDUserReviewsConfig } from '../dto/user-reviews';
 import { fetchPage } from '../fetchers';
-import { sleep } from '../helpers/global.helper';
+import { extractId, sleep } from '../helpers/global.helper';
 import {
   getUserReviewColorRating,
   getUserReviewDate,
@@ -24,9 +24,14 @@ export class UserReviewsScraper {
     config?: CSFDUserReviewsConfig,
     options?: CSFDOptions
   ): Promise<CSFDUserReviews[]> {
+    const id = extractId(user);
+    if (id === null || isNaN(id)) {
+      throw new Error('node-csfd-api: user could not be extracted. Provide a valid number, numeric string, slug, or URL.');
+    }
+
     let allReviews: CSFDUserReviews[] = [];
     const pageToFetch = config?.page || 1;
-    const url = userReviewsUrl(user, pageToFetch > 1 ? pageToFetch : undefined, {
+    const url = userReviewsUrl(id, pageToFetch > 1 ? pageToFetch : undefined, {
       language: options?.language
     });
     const response = await fetchPage(url, { ...options?.request });
@@ -42,7 +47,7 @@ export class UserReviewsScraper {
     if (config?.allPages) {
       for (let i = 2; i <= pages; i++) {
         config.onProgress?.(i, pages);
-        const url = userReviewsUrl(user, i, { language: options?.language });
+        const url = userReviewsUrl(id, i, { language: options?.language });
         const response = await fetchPage(url, { ...options?.request });
 
         const items = parse(response);

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -1,5 +1,28 @@
 import { describe, expect, test } from 'vitest';
-import { addProtocol, parseColor, parseIdFromUrl } from '../src/helpers/global.helper';
+import { addProtocol, extractId, parseColor, parseIdFromUrl } from '../src/helpers/global.helper';
+
+describe('Extract Id', () => {
+  test('Handle number', () => {
+    const id = extractId(1234);
+    expect(id).toBe(1234);
+  });
+  test('Handle string number', () => {
+    const id = extractId('1234');
+    expect(id).toBe(1234);
+  });
+  test('Handle slug', () => {
+    const id = extractId('1234-some-slug');
+    expect(id).toBe(1234);
+  });
+  test('Handle whole movie url', () => {
+    const id = extractId('https://www.csfd.cz/film/906693-projekt-adam/recenze/');
+    expect(id).toBe(906693);
+  });
+  test('Handle null/invalid', () => {
+    const id = extractId('bad string');
+    expect(id).toBe(null);
+  });
+});
 
 describe('Add protocol', () => {
   test('Handle without protocol', () => {

--- a/tests/movie.service.test.ts
+++ b/tests/movie.service.test.ts
@@ -7,7 +7,7 @@ import { movieMock } from './mocks/movie1.html';
 describe('Movie Service coverage', () => {
   test('Fetch not number directly on service', async () => {
     const movieScraper = new MovieScraper();
-    await expect(movieScraper.movie(Number.NaN)).rejects.toThrow('movieId must be a valid number');
+    await expect(movieScraper.movie(Number.NaN)).rejects.toThrow('node-csfd-api: movieId could not be extracted');
   });
 
   test('JSON-LD parse fails gracefully', async () => {


### PR DESCRIPTION
💡 What:
Introduces an `extractId` helper function in `global.helper.ts` and rolls it out to `movie`, `creator`, `userRatings`, and `userReviews` services. Updates typings in `src/index.ts` so developers can now pass a number, a string slug, or a full URL to any of these methods.

🎯 Why:
To drastically reduce boilerplate for developers using this library. Previously, if developers had a CSFD URL or slug (e.g. `'912-bart'`), they had to manually parse and convert it to a Number before using the API. Now, they can confidently throw raw slugs and URLs straight into the top-level API methods, and it "just works."

🚀 Examples:
**Before:**
```ts
const id = parseIdSomehow('https://www.csfd.cz/uzivatel/912-bart/');
const ratings = await csfd.userRatings(+id);
```

**After:**
```ts
const ratings = await csfd.userRatings('https://www.csfd.cz/uzivatel/912-bart/');
// OR
const ratings = await csfd.userRatings('912-bart');
```

---
*PR created automatically by Jules for task [2850972770000787610](https://jules.google.com/task/2850972770000787610) started by @bartholomej*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API methods now accept movie and creator identifiers in multiple formats: numeric IDs, numeric strings, URL slugs, or full CSFD URLs for increased flexibility.

* **Tests**
  * Added comprehensive test coverage for ID format parsing and validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bartholomej/node-csfd-api/pull/189)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->