### PR TITLE
🛠️ DX: allow userRatings and userReviews to accept URLs

### DIFF
--- a/src/helpers/global.helper.ts
+++ b/src/helpers/global.helper.ts
@@ -16,6 +16,10 @@ export const parseIdFromUrl = (url: string): number => {
     if (/^\d+-/.test(p)) {
       return +p.split('-')[0] || null;
     }
+    // Also support pure numbers in URL parts (e.g., /uzivatel/1000/)
+    if (/^\d+$/.test(p)) {
+      return +p || null;
+    }
   }
 
   // Fallback

--- a/src/services/user-ratings.service.ts
+++ b/src/services/user-ratings.service.ts
@@ -2,7 +2,7 @@ import { HTMLElement, parse } from 'node-html-parser';
 import { CSFDColorRating, CSFDFilmTypes, CSFDStars } from '../dto/global';
 import { CSFDUserRatingConfig, CSFDUserRatings } from '../dto/user-ratings';
 import { fetchPage } from '../fetchers';
-import { sleep } from '../helpers/global.helper';
+import { extractId, sleep } from '../helpers/global.helper';
 import {
   getUserRating,
   getUserRatingColorRating,
@@ -22,9 +22,14 @@ export class UserRatingsScraper {
     config?: CSFDUserRatingConfig,
     options?: CSFDOptions
   ): Promise<CSFDUserRatings[]> {
+    const id = extractId(user);
+    if (id === null || isNaN(id)) {
+      throw new Error('node-csfd-api: user must be a valid number or URL');
+    }
+
     let allMovies: CSFDUserRatings[] = [];
     const pageToFetch = config?.page || 1;
-    const url = userRatingsUrl(user, pageToFetch > 1 ? pageToFetch : undefined, {
+    const url = userRatingsUrl(id, pageToFetch > 1 ? pageToFetch : undefined, {
       language: options?.language
     });
     const response = await fetchPage(url, { ...options?.request });
@@ -40,7 +45,7 @@ export class UserRatingsScraper {
     if (config?.allPages) {
       for (let i = 2; i <= pages; i++) {
         config.onProgress?.(i, pages);
-        const url = userRatingsUrl(user, i, { language: options?.language });
+        const url = userRatingsUrl(id, i, { language: options?.language });
         const response = await fetchPage(url, { ...options?.request });
 
         const items = parse(response);

--- a/src/services/user-reviews.service.ts
+++ b/src/services/user-reviews.service.ts
@@ -2,7 +2,7 @@ import { HTMLElement, parse } from 'node-html-parser';
 import { CSFDColorRating, CSFDFilmTypes, CSFDStars } from '../dto/global';
 import { CSFDUserReviews, CSFDUserReviewsConfig } from '../dto/user-reviews';
 import { fetchPage } from '../fetchers';
-import { sleep } from '../helpers/global.helper';
+import { extractId, sleep } from '../helpers/global.helper';
 import {
   getUserReviewColorRating,
   getUserReviewDate,
@@ -24,9 +24,14 @@ export class UserReviewsScraper {
     config?: CSFDUserReviewsConfig,
     options?: CSFDOptions
   ): Promise<CSFDUserReviews[]> {
+    const id = extractId(user);
+    if (id === null || isNaN(id)) {
+      throw new Error('node-csfd-api: user must be a valid number or URL');
+    }
+
     let allReviews: CSFDUserReviews[] = [];
     const pageToFetch = config?.page || 1;
-    const url = userReviewsUrl(user, pageToFetch > 1 ? pageToFetch : undefined, {
+    const url = userReviewsUrl(id, pageToFetch > 1 ? pageToFetch : undefined, {
       language: options?.language
     });
     const response = await fetchPage(url, { ...options?.request });
@@ -42,7 +47,7 @@ export class UserReviewsScraper {
     if (config?.allPages) {
       for (let i = 2; i <= pages; i++) {
         config.onProgress?.(i, pages);
-        const url = userReviewsUrl(user, i, { language: options?.language });
+        const url = userReviewsUrl(id, i, { language: options?.language });
         const response = await fetchPage(url, { ...options?.request });
 
         const items = parse(response);


### PR DESCRIPTION
💡 What: Updated `userRatings` and `userReviews` services to use `extractId`, allowing them to accept raw numeric IDs, string IDs, slugs, and full URLs. Also improved `parseIdFromUrl` to support URLs without a text slug (e.g., `/uzivatel/1000/`).

🎯 Why: To reduce boilerplate for developers using the library. They no longer have to manually parse the numeric ID out of user profile URLs when using `csfd.userRatings()` or `csfd.userReviews()`.

🚀 Examples:
**Before:**
```typescript
const url = 'https://www.csfd.cz/uzivatel/1000-pomoc/';
// Needed to parse the ID manually
const result = await csfd.userRatings(1000); 
```

**After:**
```typescript
const url = 'https://www.csfd.cz/uzivatel/1000-pomoc/';
// Works out of the box!
const result = await csfd.userRatings(url); 
```

---
*PR created automatically by Jules for task [3544235191838941380](https://jules.google.com/task/3544235191838941380) started by @bartholomej*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * URL parsing now properly recognizes numeric user identifiers in both direct path segments (e.g., `/user/1000/`) and formatted URL slugs
  * User ratings and reviews services now extract and validate user identifiers before making requests, preventing potential errors from invalid inputs
  * Pagination requests for user ratings and reviews now consistently use validated identifiers

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bartholomej/node-csfd-api/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->