### PR TITLE
🛠️ DX: Support URL and text slug parsing in User APIs

### DIFF
--- a/src/helpers/global.helper.ts
+++ b/src/helpers/global.helper.ts
@@ -50,6 +50,33 @@ export const extractId = (idOrUrl: number | string): number | null => {
   return null;
 };
 
+/**
+ * Extracts a user identifier (numeric ID or slug) from a number, string, slug, or full URL.
+ * Designed for Developer Experience (DX) to allow flexible inputs for user endpoints.
+ */
+export const extractUser = (userOrUrl: number | string): string | number => {
+  if (typeof userOrUrl === 'number') {
+    return userOrUrl;
+  }
+
+  if (typeof userOrUrl === 'string') {
+    const trimmed = userOrUrl.trim();
+    if (/^\d+$/.test(trimmed)) {
+      return Number(trimmed);
+    }
+
+    // Check for URL containing /uzivatel/
+    const match = trimmed.match(/\/uzivatel\/([^\/]+)/);
+    if (match) {
+      return match[1];
+    }
+
+    return trimmed;
+  }
+
+  return userOrUrl;
+};
+
 export const parseLastIdFromUrl = (url: string): number => {
   if (url) {
     const idSlug = url?.split('/')[3];

--- a/src/services/user-ratings.service.ts
+++ b/src/services/user-ratings.service.ts
@@ -2,7 +2,7 @@ import { HTMLElement, parse } from 'node-html-parser';
 import { CSFDColorRating, CSFDFilmTypes, CSFDStars } from '../dto/global';
 import { CSFDUserRatingConfig, CSFDUserRatings } from '../dto/user-ratings';
 import { fetchPage } from '../fetchers';
-import { sleep } from '../helpers/global.helper';
+import { extractUser, sleep } from '../helpers/global.helper';
 import {
   getUserRating,
   getUserRatingColorRating,
@@ -22,9 +22,13 @@ export class UserRatingsScraper {
     config?: CSFDUserRatingConfig,
     options?: CSFDOptions
   ): Promise<CSFDUserRatings[]> {
+    const extractedUser = extractUser(user);
+    if (extractedUser === null || extractedUser === undefined || extractedUser === '') {
+      throw new Error('node-csfd-api: user must be a valid user ID or slug');
+    }
     let allMovies: CSFDUserRatings[] = [];
     const pageToFetch = config?.page || 1;
-    const url = userRatingsUrl(user, pageToFetch > 1 ? pageToFetch : undefined, {
+    const url = userRatingsUrl(extractedUser, pageToFetch > 1 ? pageToFetch : undefined, {
       language: options?.language
     });
     const response = await fetchPage(url, { ...options?.request });
@@ -40,7 +44,7 @@ export class UserRatingsScraper {
     if (config?.allPages) {
       for (let i = 2; i <= pages; i++) {
         config.onProgress?.(i, pages);
-        const url = userRatingsUrl(user, i, { language: options?.language });
+        const url = userRatingsUrl(extractedUser, i, { language: options?.language });
         const response = await fetchPage(url, { ...options?.request });
 
         const items = parse(response);

--- a/src/services/user-reviews.service.ts
+++ b/src/services/user-reviews.service.ts
@@ -2,7 +2,7 @@ import { HTMLElement, parse } from 'node-html-parser';
 import { CSFDColorRating, CSFDFilmTypes, CSFDStars } from '../dto/global';
 import { CSFDUserReviews, CSFDUserReviewsConfig } from '../dto/user-reviews';
 import { fetchPage } from '../fetchers';
-import { sleep } from '../helpers/global.helper';
+import { extractUser, sleep } from '../helpers/global.helper';
 import {
   getUserReviewColorRating,
   getUserReviewDate,
@@ -24,9 +24,13 @@ export class UserReviewsScraper {
     config?: CSFDUserReviewsConfig,
     options?: CSFDOptions
   ): Promise<CSFDUserReviews[]> {
+    const extractedUser = extractUser(user);
+    if (extractedUser === null || extractedUser === undefined || extractedUser === '') {
+      throw new Error('node-csfd-api: user must be a valid user ID or slug');
+    }
     let allReviews: CSFDUserReviews[] = [];
     const pageToFetch = config?.page || 1;
-    const url = userReviewsUrl(user, pageToFetch > 1 ? pageToFetch : undefined, {
+    const url = userReviewsUrl(extractedUser, pageToFetch > 1 ? pageToFetch : undefined, {
       language: options?.language
     });
     const response = await fetchPage(url, { ...options?.request });
@@ -42,7 +46,7 @@ export class UserReviewsScraper {
     if (config?.allPages) {
       for (let i = 2; i <= pages; i++) {
         config.onProgress?.(i, pages);
-        const url = userReviewsUrl(user, i, { language: options?.language });
+        const url = userReviewsUrl(extractedUser, i, { language: options?.language });
         const response = await fetchPage(url, { ...options?.request });
 
         const items = parse(response);

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { addProtocol, extractId, parseColor, parseIdFromUrl } from '../src/helpers/global.helper';
+import { addProtocol, extractId, extractUser, parseColor, parseIdFromUrl } from '../src/helpers/global.helper';
 
 describe('Add protocol', () => {
   test('Handle without protocol', () => {
@@ -64,6 +64,30 @@ describe('extractId', () => {
   });
   test('Handle invalid strings', () => {
     expect(extractId('invalid-string')).toBe(null);
+  });
+});
+
+describe('extractUser', () => {
+  test('Handle numeric ID', () => {
+    expect(extractUser(912)).toBe(912);
+  });
+  test('Handle numeric string', () => {
+    expect(extractUser('912')).toBe(912);
+  });
+  test('Handle slug', () => {
+    expect(extractUser('912-bart')).toBe('912-bart');
+  });
+  test('Handle full URL', () => {
+    expect(extractUser('https://www.csfd.cz/uzivatel/912-bart/')).toBe('912-bart');
+  });
+  test('Handle full URL with subpath', () => {
+    expect(extractUser('https://www.csfd.cz/uzivatel/912-bart/hodnoceni/')).toBe('912-bart');
+  });
+  test('Handle relative path', () => {
+    expect(extractUser('/uzivatel/912-bart/')).toBe('912-bart');
+  });
+  test('Handle fallback for non-uzivatel strings', () => {
+    expect(extractUser('something-else')).toBe('something-else');
   });
 });
 


### PR DESCRIPTION
💡 **What**: Added an `extractUser` helper function.
🎯 **Why**: Developers can now seamlessly pass full URLs or text slugs into the user endpoints (`userRatings` and `userReviews`). Previously, this either required exact slug inputs or failed on full profile URLs, causing annoying parsing boilerplate for users. This change brings user endpoints up to parity with the `movie` and `creator` endpoints which already support `extractId`.
🚀 **Examples**:
```typescript
// Before
const userId = myUrl.split('/uzivatel/')[1].split('/')[0];
await csfd.userRatings(userId);

// After
await csfd.userRatings('https://www.csfd.cz/uzivatel/912-bart/');
```

---
*PR created automatically by Jules for task [3725825361951973973](https://jules.google.com/task/3725825361951973973) started by @bartholomej*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for normalizing user inputs from IDs, usernames, and user profile URLs.
  * User-related actions now accept either a numeric ID or a slug-style username.

* **Bug Fixes**
  * Improved validation for invalid user inputs with a clearer error message.
  * User lookup and paging now consistently use the normalized user value.

* **Tests**
  * Added coverage for numeric strings, full URLs, relative paths, and fallback string handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->